### PR TITLE
Fix typo on Portal Three Kingdoms class

### DIFF
--- a/src/expansions.less
+++ b/src/expansions.less
@@ -955,11 +955,11 @@
 	color: rgb(0, 0, 0);
 }
 
-.portal-three-kindoms:before {
+.portal-three-kingdoms:before {
 	content: "\e76d";
 	color: rgb(255, 255, 255);
 }
-.portal-three-kindoms:after {
+.portal-three-kingdoms:after {
 	content: "\e76e";
 	margin-left: -0.845703125em;
 	color: rgb(0, 0, 0);


### PR DESCRIPTION
From `.portal-three-kindoms` to `.portal-three-kingdoms`.